### PR TITLE
Change required Go version to 1.14 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [test cases](testdata/src/a/a.go) for more examples of the types of erro
 Installation
 -------------
 
-Requires Go 1.11 or above.
+Requires Go 1.14 or above.
 
 ```
 go get -u github.com/charithe/durationcheck/cmd/durationcheck


### PR DESCRIPTION
It's because [`go.mod`](https://github.com/charithe/durationcheck/blob/master/go.mod#L3) says the Go version is 1.14.