### PR TITLE
Fix: Detect erroneous multiplication assignments (x *= y)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/charithe/durationcheck
 
-go 1.14
+go 1.16
 
 require golang.org/x/tools v0.6.0

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -76,6 +76,9 @@ func validCases() {
 	_ = time.Duration(intArr[0]) * time.Second
 
 	_ = time.Duration(y) * 24 * time.Hour
+
+	x := time.Second
+	x *= time.Duration(5)
 }
 
 func invalidCases() {
@@ -114,6 +117,10 @@ func invalidCases() {
 	_ = time.Second * b.SomeDuration // want `Multiplication of durations`
 
 	_ = time.Duration(tdArr[0]) * time.Second // want `Multiplication of durations`
+
+	x *= time.Second // want `Multiplication of durations`
+
+	x *= time.Duration(5) * time.Second // want `Multiplication of durations`
 }
 
 func someDuration() time.Duration {


### PR DESCRIPTION
# Summary

This addresses a gap where multiplication assignments were not checked:

```go
package main

import "time"

func main() {
	x := time.Second
	x = x * time.Hour  // durationcheck: Multiplication of durations
	x *= time.Hour     // nothing
}
```

I recommend this linter occasionally, but `zimpenfish` pointed out it missed this case in some of their code: https://lobste.rs/c/7pbivg

PS: I updated `go.mod` to 1.16. We have a dependency on `golang.org/x/tools@v0.6.0`, which uses `io.ReadAll`. The dependency itself declares `go 1.18 // tagx:compat 1.16`, but figured I'd avoid upping the requirement more than necessary.

# Test Plan

```
> docker run -it -v=$(pwd):/app --workdir=/app --rm golang:1.16 sh -c 'go mod tidy && go test'
go: downloading golang.org/x/tools v0.6.0
go: downloading golang.org/x/sys v0.5.0
go: downloading golang.org/x/mod v0.8.0
go: downloading golang.org/x/sync v0.1.0
PASS
ok      github.com/charithe/durationcheck       0.774s
```

Using Docker because the tests are broken with Go binaries >= 1.22, but that's not our fault: https://github.com/golang/go/issues/75918#issuecomment-3437098268